### PR TITLE
bug: jumping lines on save

### DIFF
--- a/nvim/lua/config/commands/format.lua
+++ b/nvim/lua/config/commands/format.lua
@@ -2,7 +2,6 @@ local augroup = vim.api.nvim_create_augroup
 local autocmd = vim.api.nvim_create_autocmd
 local group = augroup("KokovimFormat", { clear = true })
 
-
 -- Enable autoformat for specific filetypes
 autocmd("FileType", {
   group = group,
@@ -11,9 +10,14 @@ autocmd("FileType", {
   callback = function() vim.b.autoformat = true end,
 })
 
--- Remove trailing whitespace on save
-autocmd("BufWrite", {
-  group = group,
+autocmd("BufWritePre", {
   pattern = "*",
-  command = [[%s/\s\+$//e]],
+  callback = function(args)
+    require("conform").format({
+      bufnr = args.buf,
+      lsp_fallback = true,
+      async = false,
+      timeout_ms = 1000,
+    })
+  end,
 })

--- a/nvim/lua/plugins/lsp.spec.lua
+++ b/nvim/lua/plugins/lsp.spec.lua
@@ -120,12 +120,11 @@ return {
         capabilities = capabilities,
       })
 
-
       -- Configure diaganostics
       vim.diagnostic.config({
         virtual_text = false,
         virtual_lines = false,
-        signs = opts.diagnostics.signs
+        signs = opts.diagnostics.signs,
       })
     end,
     keys = {


### PR DESCRIPTION
Moved custom cmd for trimming whitespaces to conform variant to prevent
jumping lines on save
